### PR TITLE
CP-18405 add integration tests to Travis CI using Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 
+os:
+- linux
+sudo: required
 language: c
-sudo: false
-
-matrix:
-  include:
-    - compiler: gcc
-      os: linux
+services:
+- docker
 
 script:
-  - make
-  - make test
-
+  - docker run -itv $PWD:/mnt xenserver/xenserver-build-env bash -c "cd /mnt; ./travis-ci.sh"

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,22 @@
 #
 # yum install -y ocaml-rrd-transport-devel
 #
+# We don't have an install target because installation is handled
+# from the spec file.
+
+
+NAME    = rrd-client-lib
+VERSION = 1.0.0
 
 CC	= gcc
-CFLAGS	= -std=gnu99 -g -Wall
+CFLAGS	= -std=gnu99 -g -fpic -Wall
 OBJ	+= librrd.o
 OBJ 	+= parson/parson.o
 LIB     += -lz
 
-OCB 	= ocamlbuild -use-ocamlfind
 
 .PHONY: all
-all:	librrd.a rrdtest rrdclient
+all:	librrd.a librrd.so rrdtest rrdclient
 
 .PHONY: clean
 clean:
@@ -26,7 +31,6 @@ clean:
 	rm -f rrdtest.o rrdtest
 	rm -f rrdclient.o rrdclient
 	rm -rf config.xml cov-int html coverity.out
-	cd ocaml;  $(OCB) -clean
 
 .PHONY: test
 test: 	rrdtest rrdclient
@@ -65,11 +69,19 @@ librrd.a: $(OBJ)
 	ar rc $@ $(OBJ)
 	ranlib $@
 
+librrd.so: $(OBJ)
+	$(CC) -shared -o $@ $(OBJ)
+
 rrdtest: rrdtest.o librrd.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LIB)
 
 rrdclient: rrdclient.o librrd.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LIB)
+
+.PHONY: tar
+tar: 	
+	git archive --format=tar --prefix=$(NAME)-$(VERSION)/  HEAD\
+		| gzip > $(NAME)-$(VERSION).tar.gz
 
 # coverity analysis
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test: 	rrdtest rrdclient
 	seq 1 10 | ./rrdclient rrdclient.rrd
 
 .PHONY: test-integration
-test-integration: 
+test-integration: rrdclient
 	seq 1 10 | while read i; do \
 		echo $$i | ./rrdclient rrdclient.rrd ;\
 		rrdreader file --once rrdclient.rrd v2 ;\
@@ -79,7 +79,7 @@ rrdclient: rrdclient.o librrd.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LIB)
 
 .PHONY: tar
-tar: 	
+tar:
 	git archive --format=tar --prefix=$(NAME)-$(VERSION)/  HEAD\
 		| gzip > $(NAME)-$(VERSION).tar.gz
 

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -1,0 +1,13 @@
+#! /bin/sh
+#
+# This script is run inside the Docker xenserver/xenserver-build-env
+# container on Travis.
+#
+set -e
+
+env COMMAND=":" /usr/local/bin/init-container.sh
+sudo yum install -y ocaml-rrd-transport-devel
+cd /mnt
+make
+make test
+make test-integration

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -5,6 +5,9 @@
 #
 set -e
 
+# init-container.sh executes either COMMAND or opens a login shell.
+# We just want it to do the initialisation and so we provide a dummy
+# command and do everything else explicitly here.
 env COMMAND=":" /usr/local/bin/init-container.sh
 sudo yum install -y ocaml-rrd-transport-devel
 cd /mnt


### PR DESCRIPTION
Previously Travis CI only executed basic tests but did not run integration tests that validate the binary file format the library is creating. This PR adds integration tests that are carried out in the `xenserver/xenserver-build-env` Docker container. We need the container to have the `ocaml-rrd-transport-devel` package available to carry out the integration tests.
