### PR TITLE
Add version script to prevent SO namespace collisions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ librrd.a: $(OBJ)
 	ranlib $@
 
 librrd.so: $(OBJ)
-	$(CC) -shared -o $@ $(OBJ) $(LIB)
+	$(CC) -shared -Wl,--version-script=version.script -o $@ $(OBJ) $(LIB)
 
 rrdtest: rrdtest.o librrd.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LIB)

--- a/version.script
+++ b/version.script
@@ -1,0 +1,10 @@
+{
+    global:
+        rrd_open;
+        rrd_close;
+        rrd_add_src;
+        rrd_del_src;
+        rrd_sample;
+    local:
+        *;
+};


### PR DESCRIPTION
This is particularly important as parson overlaps with json-c.

Signed-off-by: Robert Breker robert.breker@citrix.com
