### PR TITLE
Don't include parson.h in librrd.h

### DIFF
--- a/librrd.h
+++ b/librrd.h
@@ -24,7 +24,6 @@
 
 #include <stdint.h>
 #include <time.h>
-#include "parson/parson.h"
 
 #define RRD_MAX_SOURCES         16
 


### PR DESCRIPTION
There's no need for it and it otherwise needs to be packaged in the RPM.

Signed-off-by: Robert Breker robert.breker@citrix.com
