### PR TITLE
Fix: use latest meta data protocol, fix compilation on OS X, test scale "absolute"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 
 NAME    = rrd-client-lib
 VERSION = 1.1.0
+OS 	:= $(shell uname)
 
 CC	= gcc
 CFLAGS	= -std=gnu99 -g -fpic -Wall
@@ -18,6 +19,11 @@ OBJ	+= librrd.o
 OBJ 	+= parson/parson.o
 LIB     += -lz
 
+ifeq ($(OS),Darwin)
+LDFLAGS = -shared -Wl
+else
+LDFLAGS = -shared -Wl,--version-script=version.script
+endif
 
 .PHONY: all
 all:	librrd.a librrd.so rrdtest rrdclient
@@ -68,7 +74,7 @@ librrd.a: $(OBJ)
 	ranlib $@
 
 librrd.so: $(OBJ)
-	$(CC) -shared -Wl,--version-script=version.script -o $@ $(OBJ) $(LIB)
+	$(CC) $(LDFLAGS) -o $@ $(OBJ) $(LIB)
 
 rrdtest: rrdtest.o librrd.a
 	$(CC) $(CFLAGS) -o $@ $^ $(LIB)

--- a/librrd.c
+++ b/librrd.c
@@ -163,7 +163,7 @@ json_for_source(RRD_SOURCE * source)
     }
     json_object_set_string(src, "value_type", value_type);
 
-#define RRD_TRANSPORT_1_0_0
+#define RRD_TRANSPORT_1_1_0
 #ifdef RRD_TRANSPORT_1_1_0
 #define GAUGE "gauge"
 #define ABSOLUTE "absolute"

--- a/rrdclient.c
+++ b/rrdclient.c
@@ -83,7 +83,7 @@ main(int argc, char **argv)
     src.owner_uuid = "931388d6-559e-11e6-ab0a-73658ca1c515";
     src.rrd_units = "numbers";
     src.type = RRD_INT64;
-    src.scale = RRD_GAUGE;
+    src.scale = RRD_ABSOLUTE;
     src.min = "-inf";
     src.max = "inf";
     src.rrd_default = 0;

--- a/rrdtest.c
+++ b/rrdtest.c
@@ -92,7 +92,7 @@ main(int argc, char **argv)
     src[1].owner = RRD_HOST;
     src[1].owner_uuid = "e8969702-5414-11e6-8cf5-47824be728c3";
     src[1].rrd_units = "points";
-    src[1].scale = RRD_GAUGE;
+    src[1].scale = RRD_ABSOLUTE;
     src[1].type = RRD_INT64;
     src[1].min = "-inf";
     src[1].max = "inf";

--- a/travis-ci.sh
+++ b/travis-ci.sh
@@ -15,3 +15,4 @@ make
 make valgrind
 make test
 make test-integration
+make clean


### PR DESCRIPTION
This PR fixes three problems:
- The recently introduced linker flag `--version-script` doesn't work on OS X. The Makefile now detects this and doesn't use it. While OS X is not our main target, this keeps the code compiling and documents the issue.
- Use a wider range of test cases to detect protocol discrepancies between client and server. In particular, use a different scale than `GAUGE` because this is not suited to detect them.
- Fix a protocol incompatibility detected by the above tests. The library now writes the most recent version of the meta data. This problem was previously reported by @robertbreker by email.

The changes pass the Travis CI which has been slightly extended to also exercise the `clean` Make target.
