### PR TITLE
CA-223651 fix meta data for VM and SR owner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ test: 	rrdtest rrdclient
 test-integration: rrdclient
 	seq 1 10 | while read i; do echo $$i ; sleep 4; done \
 		| ./rrdclient rrdclient.rrd &
+	sleep 2
 	rrdreader file rrdclient.rrd v2 \
 		|| echo "a final exception Rrd_protocol.No_update is OK"
 	test ! -f rrdclient.rrd

--- a/librrd.c
+++ b/librrd.c
@@ -134,7 +134,7 @@ json_for_source(RRD_SOURCE * source)
     json_object_set_string(src, "default",
                            source->rrd_default ? "true" : "false");
 
-    char           owner[128];
+    char           owner[128] = {0};
 
     switch (source->owner) {
     case RRD_HOST:

--- a/librrd.c
+++ b/librrd.c
@@ -134,16 +134,17 @@ json_for_source(RRD_SOURCE * source)
     json_object_set_string(src, "default",
                            source->rrd_default ? "true" : "false");
 
-    char           *owner = NULL;
+    char           owner[128];
+
     switch (source->owner) {
     case RRD_HOST:
-        owner = "host";
+        snprintf(owner, sizeof owner, "host");
         break;
     case RRD_VM:
-        owner = "vm";
+        snprintf(owner, sizeof owner, "vm %s", source->owner_uuid);
         break;
     case RRD_SR:
-        owner = "rrd";
+        snprintf(owner, sizeof owner, "sr %s", source->owner_uuid);
         break;
     default:
         abort();

--- a/rrdclient.c
+++ b/rrdclient.c
@@ -79,7 +79,7 @@ main(int argc, char **argv)
 
     src.name = "stdin";
     src.description = "integers read from stdin";
-    src.owner = RRD_HOST;
+    src.owner = RRD_VM;
     src.owner_uuid = "931388d6-559e-11e6-ab0a-73658ca1c515";
     src.rrd_units = "numbers";
     src.type = RRD_INT64;


### PR DESCRIPTION
This PR fixes how meta data is created for a VM and VR data source owner and changes the integration test to test the VM case (was HOST). Once this goes in, I'll tag this and update the SPEC file.
