### PR TITLE
Add --disable-fb flag for Coverity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ COV_OPTS += --all
 COV_OPTS += --rule
 COV_OPTS += --disable-parse-warnings
 COV_OPTS += --enable-fnptr
+COV_OPTS += --disable-fb
 
 COV_DIR = cov-int
 


### PR DESCRIPTION
The --disable-fb flag for Coverity is recommended to mitigate risks around log4j. This is in the Makefile which invokes Coverity. This project by itself has no dependency on log4j. 

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>