### PR TITLE
librrd: Get timestamp at a higher precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ considered private to the library.
 
 The name of the plugin is descriptive, as whether it reports data
 for a single machine (`RRD_LOCAL_DOMAIN`) or multiple
-(`RRD_INTER_DOMAIN`). The second parameter of `rrd_sample` is typically
-NULL. If it isn't, it us used to obtain a timestamp instead of using
-time(3).
+(`RRD_INTER_DOMAIN`). The second parameter of `rrd_sample` is deprecated
+and will be ignored (and should be NULL).
 
 When a plugin is opened, the file at `path` is being created and it is
 removed when the plugin is closed.

--- a/librrd.c
+++ b/librrd.c
@@ -218,6 +218,14 @@ json_for_plugin(RRD_PLUGIN * plugin)
     }
     return root_json;
 }
+
+double get_timestamp()
+{
+    struct timeval tp;
+    gettimeofday(&tp, NULL);
+    return (double) tp.tv_sec + (double) tp.tv_usec / 1e6;
+}
+
 /*
  * initialise the buffer that we update and write out to a file. Once
  * initialised, it is kept up to date by sample().
@@ -263,7 +271,7 @@ initialise(RRD_PLUGIN * plugin)
     memcpy(&header->rrd_magic, MAGIC, MAGIC_SIZE);
     header->rrd_checksum_value = htonl(0x01234567);
     header->rrd_header_datasources = htonl(plugin->n);
-    header->rrd_timestamp = htonll((uint64_t) time(NULL));
+    header->rrd_timestamp = htonll(get_timestamp());
     if (header->rrd_timestamp == -1) {
         free(plugin->buf);
         plugin->buf_size = 0;
@@ -450,7 +458,7 @@ rrd_sample(RRD_PLUGIN * plugin, time_t(*t) (time_t *))
      * update timestamp, calculate crc
      */
 
-    header->rrd_timestamp = htonll((uint64_t) (t ? t(NULL) : time(NULL)));
+    header->rrd_timestamp = htonll(get_timestamp());
     uint32_t        crc = crc32(0L, Z_NULL, 0);
     crc = crc32(crc,
                 (unsigned char *)&header->rrd_timestamp,

--- a/librrd.h
+++ b/librrd.h
@@ -23,7 +23,7 @@
 
 
 #include <stdint.h>
-#include <time.h>
+#include <sys/time.h>
 
 #define RRD_MAX_SOURCES         16
 
@@ -131,8 +131,6 @@ int             rrd_del_src(RRD_PLUGIN * plugin, RRD_SOURCE * source);
  * calling rrd_sample(plugin) triggers that all data sources are sampled
  * and the results are reported to the RRD daemon. This function needs
  * to be called every 5 seconds by the client. The second parameter is
- * typically NULL. If it isn't, it will be used instead of time(3) to
- * obtain the time stamp that is written to the RRD file. This can be
- * used to create RRD files that don't depend on the current time.
+ * deprecated and will be ignored (and should be NULL).
  */
 int             rrd_sample(RRD_PLUGIN * plugin, time_t (*t)(time_t*));


### PR DESCRIPTION
Changes the usage of `time(2)` to `gettimeofday(2)`, gaining greater precision of the timestamp transmitted to the server (now sent as a double instead of uint64). Due to different signatures of these functions, the second parameter to `rrd_sample` was deprecated and is now simply ignored. No known users of this plugin set it to anything other than NULL so this is not disruptive.

This follows the change in the RRD protocol upstream.

===

Needs to be carefully coordinated with the main changes! Update guidance needs to be figured out too.